### PR TITLE
don't clear the panel of the root element that is supposed to contain…

### DIFF
--- a/v-ol2/src/main/java/org/vaadin/vol/client/OpenLayersMapConnector.java
+++ b/v-ol2/src/main/java/org/vaadin/vol/client/OpenLayersMapConnector.java
@@ -45,13 +45,15 @@ public class OpenLayersMapConnector extends AbstractComponentContainerConnector 
     @Override
     public void onConnectorHierarchyChange(ConnectorHierarchyChangeEvent event) {
         Profiler.enter("OpenLayersMapConnector.onConnectorHierarchyChange");
-        Profiler.enter("OpenLayersMapConnector.onConnectorHierarchyChange add children");
+        Profiler.enter(
+                "OpenLayersMapConnector.onConnectorHierarchyChange add children");
 
-        getWidget().clear();
+        getWidget().getFakePaintables().clear();
         for (ComponentConnector child : getChildComponents()) {
-            getWidget().add(child.getWidget());
+            getWidget().getFakePaintables().add(child.getWidget());
         }
-        Profiler.leave("OpenLayersMapConnector.onConnectorHierarchyChange add children");
+        Profiler.leave(
+                "OpenLayersMapConnector.onConnectorHierarchyChange add children");
         Profiler.leave("OpenLayersMapConnector.onConnectorHierarchyChange");
     }
 

--- a/v-ol2/src/main/java/org/vaadin/vol/client/ui/VOpenLayersMap.java
+++ b/v-ol2/src/main/java/org/vaadin/vol/client/ui/VOpenLayersMap.java
@@ -61,6 +61,9 @@ public class VOpenLayersMap extends FlowPanel {
         setStyleName(CLASSNAME);
     }
 
+    public FlowPanel getFakePaintables() {
+        return fakePaintables;
+    }
 
     private int getWindowClickTopPosition(ContextMenuEvent event) {
         return WidgetUtil.getTouchOrMouseClientY(event.getNativeEvent())


### PR DESCRIPTION
… the actual map

Did some console.log style debugging. This should make the actual OL map widget initialize. There is still though some timing issues that you might need to resolve. At least I didn't yet get e.g. a simple OSM layer to appear. But I hope this helps you to get forward!

The test server in add-on project and GWT development mode should be somehow set up for proper development...
